### PR TITLE
Adds support for GraphQL query variables and variant definition for the styleguide

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ This also means that you can reuse the same query by using different alias:
 }
 ```
 
+#### Using fragments
+
 Because _This is just GraphQL™_, you can also create fragments that can then be included in other queries:
 
 ```js
@@ -307,6 +309,8 @@ const otherH1Styles = gql`
 
 This is a powerful pattern that avoids lots of repetitions and allows for a bigger separation of concerns.
 
+#### Defining custom unit
+
 You can also override the pre-defined unit directly in your query by using the argument `unit`:
 
 ```js
@@ -321,6 +325,39 @@ You can also override the pre-defined unit directly in your query by using the a
 ```
 
 This will return `marginLeft: 24em, paddingTop: 32px`.
+
+#### Using style variations (theming)
+
+One of the big advantages of CSS-in-GQL™ is that you can use the power of variables to build custom queries. In `graphql-css` that means that we can easily define variants (think themes) for specific components.
+
+```js
+const styles = {
+    theme: {
+        light: {
+            button: {
+                // button light styles
+            },
+        },
+        dark: {
+            button: {
+                // button dark styles
+            },
+        },
+    },
+};
+
+const stateStyles = gql`
+    {
+        theme(variant: $variant) {
+            button
+        }
+    }
+`;
+
+// This can also be a stateful component that changes the variant according to state.
+// Please check the examples folder for a detailed example.
+const StyledComponent = gqlCSS(styles)(stateStyles, null, { variant: "light" });
+```
 
 ## Developing
 

--- a/examples/App.jsx
+++ b/examples/App.jsx
@@ -6,38 +6,42 @@ import glamorous from "glamorous";
 
 const h2Styles = gql`
     {
-        typography {
-            fontSize: scale {
-                l
+        base {
+            typography {
+                fontSize: scale {
+                    l
+                }
+                fontWeight: weight {
+                    bold
+                }
             }
-            fontWeight: weight {
-                bold
+            marginLeft: spacing {
+                xl
             }
-        }
-        marginLeft: spacing {
-            xl
-        }
-        color: colors {
-            green
+            color: colors {
+                green
+            }
         }
     }
 `;
 
 const h1Styles = gql`
     fragment H1 on styles {
-        typography {
-            fontSize: scale {
-                xl
+        base {
+            typography {
+                fontSize: scale {
+                    xl
+                }
+                fontWeight: weight {
+                    bold
+                }
             }
-            fontWeight: weight {
-                bold
+            marginLeft: spacing {
+                l
             }
-        }
-        marginLeft: spacing {
-            l
-        }
-        color: colors {
-            red
+            color: colors {
+                red
+            }
         }
     }
 `;
@@ -46,32 +50,67 @@ const customH1Styles = gql`
     ${h1Styles}
     {
         ...H1
-        marginLeft: spacing(unit: "em") {
-            s
-        }
-        color: colors {
-            blue
+        base {
+            marginLeft: spacing(unit: "em") {
+                s
+            }
+            color: colors {
+                blue
+            }
         }
     }
 `;
+
+const todoStyles = gql`
+    {
+        todo(variant: $variant) {
+            text
+        }
+    }
+`;
+
+class StateComponent extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            variant: "normal",
+        };
+        this.toggleVariant = this.toggleVariant.bind(this);
+    }
+
+    toggleVariant() {
+        this.setState(state => ({
+            variant: state.variant === "normal" ? "done" : "normal",
+        }));
+    }
+
+    render() {
+        return (
+            <GqlCSS
+                styles={styles}
+                query={todoStyles}
+                variables={{ variant: this.state.variant }}
+                onClick={this.toggleVariant}
+            >
+                Using stateful component
+            </GqlCSS>
+        );
+    }
+}
 
 // Generates H2 glamorous component
 const H2 = gqlCSS(styles)(h2Styles, "h2");
 
 // Simulates existing H2 component
-const H2Comp = (props) => <h2 {...props} />
+const H2Comp = props => <h2 {...props} />;
 
 // Extracts styles object
 const inlineStyles = gqlCSS(styles)(h2Styles, false);
 
 // Simulates existing component that is enhanced by the HOC
-const ExistingComponent = ({ gqlStyles, ...rest }) => (
-    <glamorous.Div css={gqlStyles} {...rest} />
-);
+const ExistingComponent = ({ gqlStyles, ...rest }) => <glamorous.Div css={gqlStyles} {...rest} />;
 
 const HOCStyledComponent = withGqlCSS(styles, customH1Styles)(ExistingComponent);
-
-
 
 const App = () => (
     <div>
@@ -79,6 +118,7 @@ const App = () => (
         <GqlCSS styles={styles} query={h2Styles} component={H2Comp}>
             Using component
         </GqlCSS>
+        <StateComponent />
         <GqlCSSProvider styles={styles}>
             <div>
                 <div>

--- a/examples/App.jsx
+++ b/examples/App.jsx
@@ -1,116 +1,21 @@
 import React from "react";
 import styles from "./styleguide";
-import gqlCSS, { GqlCSS, GqlCSSProvider, withGqlCSS, WithGqlCSS } from "../lib";
+import gqlCSS, { GqlCSS, GqlCSSProvider, WithGqlCSS } from "../lib";
 import gql from "graphql-tag";
 import glamorous from "glamorous";
-
-const h2Styles = gql`
-    {
-        base {
-            typography {
-                fontSize: scale {
-                    l
-                }
-                fontWeight: weight {
-                    bold
-                }
-            }
-            marginLeft: spacing {
-                xl
-            }
-            color: colors {
-                green
-            }
-        }
-    }
-`;
-
-const h1Styles = gql`
-    fragment H1 on styles {
-        base {
-            typography {
-                fontSize: scale {
-                    xl
-                }
-                fontWeight: weight {
-                    bold
-                }
-            }
-            marginLeft: spacing {
-                l
-            }
-            color: colors {
-                red
-            }
-        }
-    }
-`;
-
-const customH1Styles = gql`
-    ${h1Styles}
-    {
-        ...H1
-        base {
-            marginLeft: spacing(unit: "em") {
-                s
-            }
-            color: colors {
-                blue
-            }
-        }
-    }
-`;
-
-const todoStyles = gql`
-    {
-        todo(variant: $variant) {
-            text
-        }
-    }
-`;
-
-class StateComponent extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            variant: "normal",
-        };
-        this.toggleVariant = this.toggleVariant.bind(this);
-    }
-
-    toggleVariant() {
-        this.setState(state => ({
-            variant: state.variant === "normal" ? "done" : "normal",
-        }));
-    }
-
-    render() {
-        return (
-            <GqlCSS
-                styles={styles}
-                query={todoStyles}
-                variables={{ variant: this.state.variant }}
-                onClick={this.toggleVariant}
-            >
-                Using stateful component
-            </GqlCSS>
-        );
-    }
-}
+import HOCStyledComponent from "./HOC";
+import SubscriberComponent from "./SubscriberComponent";
+import StatefulComponent from "./StatefulComponent";
+import { h2Styles } from "./styleQueries";
 
 // Generates H2 glamorous component
 const H2 = gqlCSS(styles)(h2Styles, "h2");
 
 // Simulates existing H2 component
-const H2Comp = props => <h2 {...props} />;
+const H2Comp = (props) => <h2 {...props} />
 
 // Extracts styles object
 const inlineStyles = gqlCSS(styles)(h2Styles, false);
-
-// Simulates existing component that is enhanced by the HOC
-const ExistingComponent = ({ gqlStyles, ...rest }) => <glamorous.Div css={gqlStyles} {...rest} />;
-
-const HOCStyledComponent = withGqlCSS(styles, customH1Styles)(ExistingComponent);
 
 const App = () => (
     <div>
@@ -118,24 +23,15 @@ const App = () => (
         <GqlCSS styles={styles} query={h2Styles} component={H2Comp}>
             Using component
         </GqlCSS>
-        <StateComponent />
         <GqlCSSProvider styles={styles}>
-            <div>
-                <div>
-                    <span>
-                        <GqlCSS query={h2Styles}>Using provider</GqlCSS>
-                    </span>
-                </div>
-            </div>
-            <GqlCSS query={h1Styles} css={{ marginTop: 30 }}>
-                Also using provider
-            </GqlCSS>
+            <SubscriberComponent/>
         </GqlCSSProvider>
         <h2 style={inlineStyles}>Inline styles</h2>
         <HOCStyledComponent>HOC Styled Component</HOCStyledComponent>
         <WithGqlCSS styles={styles} query={h2Styles}>
             {({ gqlStyles }) => <div style={gqlStyles}>Render props component</div>}
         </WithGqlCSS>
+        <StatefulComponent />
     </div>
 );
 

--- a/examples/HOC.jsx
+++ b/examples/HOC.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { withGqlCSS } from "../lib";
+import glamorous from "glamorous";
+import styles from "./styleguide";
+import { customH1Styles } from "./styleQueries";
+
+// Simulates existing component that is enhanced by the HOC
+const ExistingComponent = ({ gqlStyles, ...rest }) => (
+    <glamorous.Div css={gqlStyles} {...rest} />
+);
+
+export default withGqlCSS(styles, customH1Styles)(ExistingComponent);

--- a/examples/StatefulComponent.jsx
+++ b/examples/StatefulComponent.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import gqlCSS, { GqlCSS } from "../lib";
+import glamorous from "glamorous";
+import styles from "./styleguide";
+import { stateStyles } from "./styleQueries";
+
+class StatefulComponent extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            variant: "normal",
+        };
+        this.toggleVariant = this.toggleVariant.bind(this);
+    }
+
+    toggleVariant() {
+        this.setState(state => ({
+            variant: state.variant === "normal" ? "done" : "normal",
+        }));
+    }
+
+    render() {
+        const { variant } = this.state;
+        const OtherComponent = gqlCSS(styles)(stateStyles, null, { variant });
+
+        return (
+            <React.Fragment>
+                <GqlCSS
+                    styles={styles}
+                    query={stateStyles}
+                    variables={{ variant }}
+                    onClick={this.toggleVariant}
+                >
+                    Using stateful component
+                </GqlCSS>
+                <OtherComponent>Other sharing state</OtherComponent>
+            </React.Fragment>
+        );
+    }
+}
+
+export default StatefulComponent;

--- a/examples/SubscriberComponent.jsx
+++ b/examples/SubscriberComponent.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { GqlCSS } from "../lib";
+import { h1Styles, h2Styles } from "./styleQueries";
+
+// Simulates subscriber component
+const SubscriberComponent = () => (
+    <div>
+        <div>
+            <span>
+                <GqlCSS query={h2Styles}>Using provider</GqlCSS>
+            </span>
+        </div>
+        <GqlCSS query={h1Styles} css={{ marginTop: 30 }}>
+            Also using provider
+        </GqlCSS>
+    </div>
+);
+
+export default SubscriberComponent;

--- a/examples/styleQueries.js
+++ b/examples/styleQueries.js
@@ -1,0 +1,66 @@
+import gql from "graphql-tag";
+
+export const h2Styles = gql`
+    {
+        base {
+            typography {
+                fontSize: scale {
+                    l
+                }
+                fontWeight: weight {
+                    bold
+                }
+            }
+            marginLeft: spacing {
+                xl
+            }
+            color: colors {
+                green
+            }
+        }
+    }
+`;
+
+export const h1Styles = gql`
+    fragment H1 on styles {
+        base {
+            typography {
+                fontSize: scale {
+                    xl
+                }
+                fontWeight: weight {
+                    bold
+                }
+            }
+            marginLeft: spacing {
+                l
+            }
+            color: colors {
+                red
+            }
+        }
+    }
+`;
+
+export const customH1Styles = gql`
+    ${h1Styles}
+    {
+        ...H1
+        base {
+            marginLeft: spacing(unit: "em") {
+                s
+            }
+            color: colors {
+                blue
+            }
+        }
+    }
+`;
+
+export const stateStyles = gql`
+    {
+        theme(variant: $variant) {
+            button
+        }
+    }
+`;

--- a/examples/styleguide.js
+++ b/examples/styleguide.js
@@ -1,5 +1,5 @@
-const base = 4
-const styles = {
+const base = 4;
+const baseStyles = {
     typography: {
         scale: {
             s: base * 3,
@@ -8,7 +8,7 @@ const styles = {
             l: base * 9,
             xl: base * 13,
             xxl: base * 20,
-            unit: "px"
+            unit: "px",
         },
         weight: {
             thin: 300,
@@ -29,6 +29,28 @@ const styles = {
         blue: "blue",
         green: "green",
         red: "red",
+    },
+};
+
+const styles = {
+    base: baseStyles,
+    todo: {
+        normal: {
+            text: {
+                fontSize: baseStyles.typography.scale.l,
+                backgroundColor: baseStyles.colors.red,
+                padding: baseStyles.spacing.l,
+                cursor: "pointer"
+            },
+        },
+        done: {
+            text: {
+                fontSize: baseStyles.typography.scale.l,
+                backgroundColor: baseStyles.colors.green,
+                padding: baseStyles.spacing.l,
+                cursor: "pointer"
+            },
+        },
     },
 };
 

--- a/examples/styleguide.js
+++ b/examples/styleguide.js
@@ -34,9 +34,9 @@ const baseStyles = {
 
 const styles = {
     base: baseStyles,
-    todo: {
+    theme: {
         normal: {
-            text: {
+            button: {
                 fontSize: baseStyles.typography.scale.l,
                 backgroundColor: baseStyles.colors.red,
                 padding: baseStyles.spacing.l,
@@ -44,7 +44,7 @@ const styles = {
             },
         },
         done: {
-            text: {
+            button: {
                 fontSize: baseStyles.typography.scale.l,
                 backgroundColor: baseStyles.colors.green,
                 padding: baseStyles.spacing.l,

--- a/src/index.js
+++ b/src/index.js
@@ -32,10 +32,15 @@ const resolver = (fieldName, root = {}, args = {}, context, { resultKey }) => {
     let res = root[fieldName];
     const rootUnit = root && root.unit;
     const argsUnit = args && args.unit;
+    const argsVariant = args && args.variant;
 
     if (argsUnit || rootUnit) {
         const unit = argsUnit || rootUnit;
         res = root[fieldName] + unit;
+    }
+
+    if (argsVariant) {
+        res = root[fieldName][argsVariant];
     }
 
     // if has prop then use it as the key
@@ -49,8 +54,8 @@ const resolver = (fieldName, root = {}, args = {}, context, { resultKey }) => {
 };
 
 // Main function to generate glamorous component with styles
-const gqlCSS = styles => (query, component = "div") => {
-    const generatedStyles = graphql(resolver, query, styles, null, null);
+const gqlCSS = styles => (query, component = "div", variables) => {
+    const generatedStyles = graphql(resolver, query, styles, null, variables);
     const smooshedStyles = smoosh(generatedStyles);
 
     // Returns just smooshed styles if component is false
@@ -59,15 +64,15 @@ const gqlCSS = styles => (query, component = "div") => {
     }
 
     // Create glamorous component
-    return glamorous(component)(smooshedStyles);
+    return glamorous(component || "div")(smooshedStyles);
 };
 
 // Also export component for more declarative API
-export const GqlCSS = ({ styles, query, component = "div", ...rest }) => {
+export const GqlCSS = ({ styles, query, component = "div", variables, ...rest }) => {
     return (
         <Subscriber quiet={true} channel="graphqlcss">
             {contextStyles => {
-                const Component = gqlCSS(styles || contextStyles || "")(query, component);
+                const Component = gqlCSS(styles || contextStyles || "")(query, component, variables);
                 return <Component {...rest} />;
             }}
         </Subscriber>
@@ -82,17 +87,17 @@ export const GqlCSSProvider = ({ styles, children }) => (
 );
 
 // Export HOC - uses render props underneath, because it's awesome
-export const withGqlCSS = (styles, query) => Component => props => {
+export const withGqlCSS = (styles, query, variables) => Component => props => {
     return (
-        <WithGqlCSS styles={styles} query={query}>
+        <WithGqlCSS styles={styles} query={query} variables={variables}>
             {({ gqlStyles }) => <Component {...props} gqlStyles={gqlStyles} />}
         </WithGqlCSS>
     );
 };
 
 // Export render props component
-export const WithGqlCSS = ({ styles, query, children, ...rest }) => {
-    const processedStyles = gqlCSS(styles)(query, false);
+export const WithGqlCSS = ({ styles, query, variables, children, ...rest }) => {
+    const processedStyles = gqlCSS(styles)(query, false, variables);
     return children({ gqlStyles: processedStyles, ...rest });
 };
 


### PR DESCRIPTION
This enables the support of variables in the GQL queries, which can be necessary for the `variant` argument.

It means that it's now possible to easily change the style of a component based on the state of the application as seen in the `StatefulComponent` example.

TODO:
- [x] Update README